### PR TITLE
Fix/enddate

### DIFF
--- a/components/SparplanForm.vue
+++ b/components/SparplanForm.vue
@@ -14,6 +14,8 @@ const emit = defineEmits<{
 const einmalZahlung = ref(0);
 const dynamik = ref(false);
 
+let input
+
 
 // form data (user input)
 const sparplanInput = reactive({
@@ -61,15 +63,15 @@ watch(() => sparplanInput.oneTimeInvestmentDate, () => {
     setEndDateToBiggestDate(sparplanInput)
 }, { deep:true })
 
-watch(() => sparplanInput.end, () => {
-  setEndDateToBiggestDate(sparplanInput)
-})
+
 
 watch(()=>sparplanInput.savingPlanEnd, () =>{
   setEndDateToBiggestDate(sparplanInput)
   if(new Date(sparplanInput.savingPlanEnd)<new Date(sparplanInput.savingPlanStart))
     sparplanInput.savingPlanEnd=sparplanInput.savingPlanStart
 })
+
+
 </script>
 
 <template>
@@ -407,6 +409,7 @@ watch(()=>sparplanInput.savingPlanEnd, () =>{
             type="date"
             class="bg-white rounded"
             :disabled="sparplanInput.endpoint==''||sparplanInput.endpoint=='end-date'"
+            v-on:blur="setEndDateToBiggestDate(sparplanInput)"
           ></v-text-field>
         </v-col>
       </v-row>

--- a/composables/useFinanceMathFetch.ts
+++ b/composables/useFinanceMathFetch.ts
@@ -7,7 +7,13 @@ export const useFinanceMathFetch = <DataT>(endpoint: string, paramInput: finance
   const keys = Object.keys(paramInput) as Array<keyof typeof paramInput>
   for (const [i, key] of keys.entries()) {
     if (paramInput[key] !== (undefined || "") && key !== 'endpoint') {
-      url += `${String(key)}=${paramInput[key]}&`
+      if(Array.isArray(paramInput[key])){
+        paramInput[key].forEach(item => {
+          url += `${String(key)}=${item}&`;
+        });
+      }else{
+        url += `${String(key)}=${paramInput[key]}&`
+      }
     }
   }
   url = url.slice(0, -1) // Remove trailing '&'

--- a/utils/formUtils.ts
+++ b/utils/formUtils.ts
@@ -47,11 +47,11 @@ export const findBiggestDate = (dates: string[]): string => {
 
 export const validateInput = (userInput:financeMathInput): void => {
      // Set decimal separator to dot and make numbers to integer
-     userInput.endValue = Math.round(formatNumber(userInput.endValue));
-     userInput.savingRate = Math.round(formatNumber(userInput.savingRate));
+     userInput.endValue = Math.round(formatNumber(userInput.endValue)*100);
+     userInput.savingRate = Math.round(formatNumber(userInput.savingRate)*100);
      userInput.interestRate= formatNumber(userInput.interestRate) * 0.01;
      userInput.dynamicSavingRateFactor = formatNumber(userInput.dynamicSavingRateFactor) * 0.01;
-     userInput.oneTimeInvestment= userInput.oneTimeInvestment.map(investment => Math.round(formatNumber(investment)))
+     userInput.oneTimeInvestment= userInput.oneTimeInvestment.map(investment => Math.round(formatNumber(investment)*100))
       // Date validation
       let tmp: string[] = (JSON.parse(JSON.stringify(userInput.oneTimeInvestmentDate)))
       tmp.push(userInput.savingPlanBegin)
@@ -64,4 +64,8 @@ export const setEndDateToBiggestDate = (userInput:financeMathInput): void => {
   tmp.push(JSON.parse(JSON.stringify(userInput.savingPlanEnd)))
   tmp.push(JSON.parse(JSON.stringify(userInput.end)))
   userInput.end = findBiggestDate(tmp)
+}
+
+export const Enddate = (enddate: string)=>{
+
 }


### PR DESCRIPTION
I did the following changes: 

- in SparplanForm.vue: after the enddate field lost focus, the enddate is validated to be the biggest date
- in useFinanceMathFetch.ts: now nested arrays like mutiple onetimeinvestement(date) are properly processed 
- in formUtils.ts: multiply each monetary unit with 100, so that the smallest possible unit is pass to the API