### PR TITLE
renamed radio button labels for readability

### DIFF
--- a/components/EntnahmeForm.vue
+++ b/components/EntnahmeForm.vue
@@ -580,7 +580,7 @@ watch(
               <v-col cols="auto" class="flex px-0 py-0">
                 <v-radio
                   disabled
-                  label="Entnahmezins"
+                  label="Verzinsung"
                   value="interest-rate"
                   density="compact"
                 ></v-radio>

--- a/components/SparplanForm.vue
+++ b/components/SparplanForm.vue
@@ -534,7 +534,7 @@ watch(
             <v-row class="py-0 ps-5">
               <v-col cols="auto" class="flex px-0 py-0">
                 <v-radio
-                  label="Sparzins"
+                  label="Verzinsung"
                   value="interest-rate"
                   density="compact"
                 ></v-radio>


### PR DESCRIPTION
renaming was necessary due inexistent of words "Entnamezins" and "Sparzins"

didnt rename in form "Kombi" because seperation of both labels is necessary